### PR TITLE
Close stdin / stdout / stderr in child process after fork

### DIFF
--- a/god.c
+++ b/god.c
@@ -174,6 +174,9 @@ int main(int argc, char **argv) {
 			if ((pid = fork())) {
 				exit(0);
 			} else if (!pid) {
+				close(0);
+				close(1);
+				close(2);
 				daemon_main(optind, argv);
 			} else {
 				perror("fork");

--- a/god.c
+++ b/god.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 	if (!(exec_stat.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH))) {
-		fprintf(stderr, "file %s doesn't look executable\n",
+		fprintf(stderr, "permission denied: %s\n",
 				argv[optind]);
 		return 1;
 	}


### PR DESCRIPTION
We use go-daemon in the [Elastic Beats](https://github.com/elastic/beats) init scripts on the platforms that don't support systemd. We occasionally [get](https://discuss.elastic.co/t/weird-filebeat-init-script-issue/35486/31) [reports](https://discuss.elastic.co/t/filebeat-service-hangs-on-first-start-amazon-ec2/46436/20) about the init scripts failing when executed over SSH, usually via some deployment tool.

#5 seems related although not quite exactly what we experience. The easiest way to reproduce the problem is to run something like this:

```
ssh host "god sleep 10"
```

SSH hangs for 10 seconds.

Closing FDs 0, 1, 2 on the first fork (the one for daemonizing the go-daemon process itself) seems necessary to detach from the pseudo tty when running in background. I did the minimal change that seems to fix our issue, but other changes might be useful as well here (setsid, redirect stdout/stderr to /dev/null), etc.