### PR TITLE
fix daemonize

### DIFF
--- a/god.c
+++ b/god.c
@@ -186,10 +186,14 @@ int main(int argc, char **argv) {
 
 	// Daemonize.
 	pid_t pid = fork();
-	if (pid) {
+	if (pid > 0) {
 		waitpid(pid, NULL, 0);
 	} else if (!pid) {
-		if ((pid = fork())) {
+		if(setsid() < 0) {
+			perror("setsid");
+			exit(1);
+		}
+		if ((pid = fork()) > 0) {
 			exit(0);
 		} else if (!pid) {
 			daemon_main(optind, argv);
@@ -218,7 +222,7 @@ void daemon_main(int optind, char **argv) {
 	}
 	signal(SIGHUP, sighup);
 	pipe(logfd);
-	if ((childpid = fork())) {
+	if ((childpid = fork()) > 0) {
 		close(0);
 		close(1);
 		close(2);


### PR DESCRIPTION
In order to become it's own session leader and fully detach from the controlling terminal a daemon must call `setsid()` in between invocations of `fork()`.

This also incorporates the fixes from #11 